### PR TITLE
feat: replace babel latest preset by env preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Clone this repo manually or use `brunch new dir -s es6`
 To use proposed JS features not included into ES6, do this:
 
 * `npm install --save-dev babel-preset-stage-0`
-* in `brunch-config.js`, add the preset: `presets: ['latest', 'stage-0']`
+* in `brunch-config.js`, add the preset: `presets: ['env', 'stage-0']`

--- a/brunch-config.js
+++ b/brunch-config.js
@@ -10,5 +10,5 @@ exports.files = {
 };
 
 exports.plugins = {
-  babel: {presets: ['latest']}
+  babel: {presets: ['env']}
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "auto-reload-brunch": "^2",
     "babel-brunch": "~6.0",
-    "babel-preset-latest": "^6",
+    "babel-preset-env": "^1",
     "brunch": "^2",
     "clean-css-brunch": "^2",
     "uglify-js-brunch": "^2"


### PR DESCRIPTION
Upgrade es6 brunch with the new requirements from babel: 
https://babeljs.io/env/
